### PR TITLE
Set `commentstring` for Commentary, add - to keywords for kebab case

### DIFF
--- a/syntax/hoon.vim
+++ b/syntax/hoon.vim
@@ -15,6 +15,8 @@ set shiftwidth=2
 " Allow gq, o, and <Enter> to understand comments
 let b:comment_leader = '::  '
 set comments=:::
+set commentstring=::%s
+set iskeyword+=-
 set fo+=rq
 
 " Don't wrap code at 72 characters, just comments


### PR DESCRIPTION
- The `'commentstring'` option needs to be set correctly for `vim-commentary` to work properly
- Hoon has kebab case keywords, so `-` should be in `iskeywords` so that `*` and word completion works